### PR TITLE
Fix import error at django startup

### DIFF
--- a/invoice/templatetags/invoice.py
+++ b/invoice/templatetags/invoice.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from django.template import Library
-from invoice import utils
+from .. import utils
 
 register = Library()
 


### PR DESCRIPTION
Without the patch I'm having this import problem.

In [1]: from invoice.templatetags import invoice
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-6bd0c948ca47> in <module>()
----> 1 from invoice.templatetags import invoice

/home/roberto/.virtualenvs/llportal/lib/python2.7/site-packages/invoice/templatetags/invoice.py in <module>()
      2 
      3 from django.template import Library
----> 4 from invoice import utils
      5 
      6 register = Library()

ImportError: cannot import name utils

In [2]: 
